### PR TITLE
Validate: Non-NA VINs don't have checksum

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ const validate = (vin, checksumParam) => {
 
   if (
     total % 11 === parseInt(checksum) ||
-    (total % 11 === 10 && checksum === 'x')
+    (total % 11 === 10 && checksum === 'x' || checksum === 'eu' || checksum === 'world')
   ) {
     return true;
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "vin-decoder",
       "version": "1.3.0",
       "license": "ISC",
       "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -13,9 +13,14 @@ describe('#validate', () => {
     validate('1NXBR32E77Z92360').should.equal(false);
   });
 
+  it('EU VINs do not have check sum', () => {
+    validate('YV1MC5851CJ126651','eu').should.equal(true);
+  });
+
   it('validate the length to be 17', () => {
     validate('1NXBR32E77Z923602').should.equal(true);
   });
+
 });
 
 describe('#split', () => {


### PR DESCRIPTION
Added support for EU and World VINs, to ignore the checksum logic:

https://www.johndcook.com/blog/2019/09/12/vin-check-sum/#:~:text=The%20check%20sum%20is%20in,the%20VIN%2C%20the%209th%20character.


`validate(vin,checksum)` now supports `checksum='eu'`  or `'world'` which will skip over the checksum logic.

Added this to test.js:

```
 it('EU VINs do not have check sum', () => {
    validate('YV1MC5851CJ126651','eu').should.equal(true);
  });
```